### PR TITLE
Use new package names, and pre-extensibility state machine interactions

### DIFF
--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AuthClient.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AuthClient.kt
@@ -3,9 +3,9 @@ package com.azuresamples.msalnativeauthandroidkotlinsampleapp
 import android.app.Application
 import android.content.Context
 import android.util.Log
-import com.microsoft.identity.client.INativeAuthPublicClientApplication
 import com.microsoft.identity.client.Logger
 import com.microsoft.identity.client.PublicClientApplication
+import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 
 object AuthClient : Application() {
     private lateinit var authClient: INativeAuthPublicClientApplication


### PR DESCRIPTION
- Use new package names (native auth classes have been moved into dedicated `nativeauth` folder)
- Use pre-extensibility state machine interactions, as extensibility improvements haven't been merged into mainline yet