### PR TITLE
Use ClientException instead of try catch block in sample app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 allprojects {
     repositories {
         maven {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -80,6 +80,9 @@ class AccessApiFragment : Fragment() {
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
                 }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
+                }
             }
         }
     }
@@ -118,7 +121,7 @@ class AccessApiFragment : Fragment() {
                     handleSignInError(actionResult)
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
                 }
             }
         }
@@ -169,7 +172,7 @@ class AccessApiFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }
@@ -225,7 +228,7 @@ class AccessApiFragment : Fragment() {
                     binding.resultText.text = getString(R.string.result_access_token_text) + accessToken
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage.toString())
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
                 }
                 else -> {
                     displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -82,7 +82,7 @@ class AccessApiFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is GetAccountError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -218,10 +218,18 @@ class AccessApiFragment : Fragment() {
 
     private fun displayAccount(accountState: AccountState) {
         CoroutineScope(Dispatchers.Main).launch {
-            val accessTokenState = accountState.getAccessToken()
-            if (accessTokenState is GetAccessTokenResult.Complete) {
-                val accessToken = accessTokenState.resultValue.accessToken
-                binding.resultText.text = accessToken
+            val accessTokenResult = accountState.getAccessToken()
+            when (accessTokenResult) {
+                is GetAccessTokenResult.Complete -> {
+                    val accessToken = accessTokenResult.resultValue.accessToken
+                    binding.resultText.text = getString(R.string.result_access_token_text) + accessToken
+                }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage.toString())
+                }
+                else -> {
+                    displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())
+                }
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -11,7 +11,6 @@ import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentAccessApiBinding
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
-import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccountError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult
@@ -103,16 +102,12 @@ class AccessApiFragment : Fragment() {
             val password = CharArray(binding.passwordText.length())
             binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
 
-                val actionResult: SignInResult
-                try {
-                    actionResult = authClient.signIn(
-                        username = email,
-                        password = password
-                    )
-                } finally {
-                    binding.passwordText.text?.clear()
-                    StringUtil.overwriteWithNull(password)
-                }
+            val actionResult: SignInResult = authClient.signIn(
+                username = email,
+                password = password
+            )
+            binding.passwordText.text?.clear()
+            StringUtil.overwriteWithNull(password)
 
             when (actionResult) {
                 is SignInResult.Complete -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -11,8 +11,8 @@ import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentAccessApiBinding
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccountError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
@@ -81,8 +81,8 @@ class AccessApiFragment : Fragment() {
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
+                is GetAccountError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
                 }
             }
         }
@@ -169,8 +169,8 @@ class AccessApiFragment : Fragment() {
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
+                is GetAccountError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -12,6 +12,7 @@ import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.Fragmen
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
@@ -120,9 +121,6 @@ class AccessApiFragment : Fragment() {
                 is SignInError -> {
                     handleSignInError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -185,7 +183,7 @@ class AccessApiFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }
@@ -227,11 +225,8 @@ class AccessApiFragment : Fragment() {
                     val accessToken = accessTokenResult.resultValue.accessToken
                     binding.resultText.text = getString(R.string.result_access_token_text) + accessToken
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
-                }
-                else -> {
-                    displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())
+                is GetAccessTokenError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message ?: accessTokenResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -102,17 +102,13 @@ class EmailAttributeSignUpFragment : Fragment() {
                 .city(city)
                 .build()
 
-            val actionResult: SignUpResult
-            try {
-                actionResult = authClient.signUp(
-                    username = email,
-                    password = password,
-                    attributes = attributes
-                )
-            } finally {
-                binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
-                StringUtil.overwriteWithNull(password)
-            }
+            val actionResult: SignUpResult = authClient.signUp(
+                username = email,
+                password = password,
+                attributes = attributes
+            )
+            binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
+            StringUtil.overwriteWithNull(password)
 
             when (actionResult) {
                 is SignUpResult.CodeRequired -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.text.set
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailAttributeBinding
@@ -137,9 +136,6 @@ class EmailAttributeSignUpFragment : Fragment() {
                 is SignUpResult.AttributesRequired -> {
                     displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -158,10 +154,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                 displaySignedInState(accountState = actionResult.resultValue)
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
-            }
-            is ClientExceptionError -> {
-                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
             }
             else -> {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
@@ -236,11 +229,8 @@ class EmailAttributeSignUpFragment : Fragment() {
                     val idToken = accountState.getIdToken()
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
-                }
-                else -> {
-                    displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())
+                is GetAccessTokenError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message ?: accessTokenResult.errorMessage)
                 }
             }
         }
@@ -255,7 +245,7 @@ class EmailAttributeSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -83,7 +83,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is GetAccountError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }
@@ -154,7 +154,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                 displaySignedInState(accountState = actionResult.resultValue)
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
+                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
             }
             else -> {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
@@ -230,7 +230,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
                 is GetAccessTokenError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message ?: accessTokenResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
                 }
             }
         }
@@ -245,7 +245,7 @@ class EmailAttributeSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -84,7 +84,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage.toString())
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }
@@ -138,7 +138,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                     displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage.toString())
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
                 }
             }
         }
@@ -161,7 +161,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                 displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
             }
             is ClientExceptionError -> {
-                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage.toString())
+                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
             }
             else -> {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
@@ -237,7 +237,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage.toString())
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
                 }
                 else -> {
                     displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.text.set
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailAttributeBinding
@@ -83,7 +84,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage.toString())
                 }
             }
         }
@@ -137,7 +138,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                     displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage.toString())
                 }
             }
         }
@@ -160,7 +161,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                 displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
             }
             is ClientExceptionError -> {
-                displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage.toString())
             }
             else -> {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
@@ -226,22 +227,21 @@ class EmailAttributeSignUpFragment : Fragment() {
 
     private fun displayAccount(accountState: AccountState) {
         CoroutineScope(Dispatchers.Main).launch {
-            try {
-                val accessTokenResult = accountState.getAccessToken()
-                when (accessTokenResult) {
-                    is GetAccessTokenResult.Complete -> {
-                        binding.resultAccessToken.text =
-                            getString(R.string.result_access_token_text) + accessTokenResult.resultValue.accessToken
+            val accessTokenResult = accountState.getAccessToken()
+            when (accessTokenResult) {
+                is GetAccessTokenResult.Complete -> {
+                    val accessToken = accessTokenResult.resultValue.accessToken
+                    binding.resultAccessToken.text = getString(R.string.result_access_token_text) + accessToken
 
-                        val idToken = accountState.getIdToken()
-                        binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
-                    }
-                    is GetAccessTokenError -> {
-                        displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message.toString())
-                    }
+                    val idToken = accountState.getIdToken()
+                    binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
-            } catch (exception: Exception) {
-                displayDialog(getString(R.string.msal_exception_title), exception.message.toString())
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage.toString())
+                }
+                else -> {
+                    displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())
+                }
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -12,8 +12,8 @@ import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.Fragmen
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.UserAttributes
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccountError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult
@@ -82,8 +82,8 @@ class EmailAttributeSignUpFragment : Fragment() {
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
+                is GetAccountError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
@@ -263,7 +263,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage.toString())
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
                 }
                 else -> {
                     displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
@@ -12,6 +12,7 @@ import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.Fragmen
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
@@ -121,9 +122,6 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                 is SignInError -> {
                     handleSignInError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -165,9 +163,6 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                 is SignUpError -> {
                     handleSignUpError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -184,10 +179,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                 displaySignedInState(accountState = actionResult.resultValue)
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
-            }
-            is ClientExceptionError -> {
-                displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
             }
             else -> {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
@@ -262,11 +254,8 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                     val idToken = accountState.getIdToken()
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
-                }
-                else -> {
-                    displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())
+                is GetAccessTokenError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message ?: accessTokenResult.errorMessage)
                 }
             }
         }
@@ -279,7 +268,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }
@@ -293,7 +282,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
@@ -96,16 +96,12 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
             val password = CharArray(binding.passwordText.length())
             binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
 
-            val actionResult: SignInResult
-            try {
-                actionResult = authClient.signIn(
-                    username = email,
-                    password = password
-                )
-            } finally {
-                binding.passwordText.text?.clear()
-                StringUtil.overwriteWithNull(password)
-            }
+            val actionResult: SignInResult = authClient.signIn(
+                username = email,
+                password = password
+            )
+            binding.passwordText.text?.clear()
+            StringUtil.overwriteWithNull(password)
 
             when (actionResult) {
                 is SignInResult.Complete -> {
@@ -132,17 +128,12 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
             val password = CharArray(binding.passwordText.length())
             binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
 
-            val actionResult: SignUpResult
-
-            try {
-                actionResult = authClient.signUp(
-                    username = email,
-                    password = password
-                )
-            } finally {
-                binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
-                StringUtil.overwriteWithNull(password)
-            }
+            val actionResult: SignUpResult = authClient.signUp(
+                username = email,
+                password = password
+            )
+            binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
+            StringUtil.overwriteWithNull(password)
 
             when (actionResult) {
                 is SignUpResult.CodeRequired -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
@@ -11,8 +11,8 @@ import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailPasswordBinding
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccountError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
@@ -83,8 +83,8 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
+                is GetAccountError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
@@ -84,7 +84,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is GetAccountError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }
@@ -179,7 +179,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                 displaySignedInState(accountState = actionResult.resultValue)
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
+                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
             }
             else -> {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
@@ -255,7 +255,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
                 is GetAccessTokenError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message ?: accessTokenResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
                 }
             }
         }
@@ -268,7 +268,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.errorMessage)
             }
         }
     }
@@ -282,7 +282,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
@@ -82,7 +82,7 @@ class EmailSignInSignUpFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is GetAccountError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }
@@ -160,7 +160,7 @@ class EmailSignInSignUpFragment : Fragment() {
                 displaySignedInState(accountState = actionResult.resultValue)
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
+                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
             }
         }
     }
@@ -232,7 +232,7 @@ class EmailSignInSignUpFragment : Fragment() {
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
                 is GetAccessTokenError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message ?: accessTokenResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
                 }
             }
         }
@@ -245,7 +245,7 @@ class EmailSignInSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_result_title), error.exception?.message ?: error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_result_title), error.errorMessage)
             }
         }
     }
@@ -258,7 +258,7 @@ class EmailSignInSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailSisuBinding
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
@@ -107,9 +108,6 @@ class EmailSignInSignUpFragment : Fragment() {
                 is SignInError -> {
                     handleSignInError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -145,9 +143,6 @@ class EmailSignInSignUpFragment : Fragment() {
                 is SignUpError -> {
                     handleSignUpError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -165,10 +160,7 @@ class EmailSignInSignUpFragment : Fragment() {
                 displaySignedInState(accountState = actionResult.resultValue)
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
-            }
-            is ClientExceptionError -> {
-                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
             }
         }
     }
@@ -239,11 +231,8 @@ class EmailSignInSignUpFragment : Fragment() {
                     val idToken = accountState.getIdToken()
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
-                }
-                else -> {
-                    displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())
+                is GetAccessTokenError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message ?: accessTokenResult.errorMessage)
                 }
             }
         }
@@ -256,7 +245,7 @@ class EmailSignInSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_result_title), error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_result_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }
@@ -269,7 +258,7 @@ class EmailSignInSignUpFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
@@ -9,8 +9,8 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailSisuBinding
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccountError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
@@ -81,8 +81,8 @@ class EmailSignInSignUpFragment : Fragment() {
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
+                is GetAccountError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
@@ -199,8 +199,8 @@ class EmailSignInSignUpFragment : Fragment() {
     private fun updateUI(status: STATUS) {
         when (status) {
             STATUS.SignedIn -> {
-                binding.signIn.isEnabled = true
-                binding.signUp.isEnabled = true
+                binding.signIn.isEnabled = false
+                binding.signUp.isEnabled = false
                 binding.signOut.isEnabled = true
             }
             STATUS.SignedOut -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
@@ -11,6 +11,7 @@ import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.Fragmen
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
@@ -80,6 +81,9 @@ class EmailSignInSignUpFragment : Fragment() {
                 }
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
+                }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message.toString())
                 }
             }
         }
@@ -230,13 +234,20 @@ class EmailSignInSignUpFragment : Fragment() {
     private fun displayAccount(accountState: AccountState) {
         CoroutineScope(Dispatchers.Main).launch {
             val accessTokenResult = accountState.getAccessToken()
-            if (accessTokenResult is GetAccessTokenResult.Complete) {
-                val accessToken = accessTokenResult.resultValue.accessToken
-                binding.resultAccessToken.text =
-                    getString(R.string.result_access_token_text) + accessToken
+            when (accessTokenResult) {
+                is GetAccessTokenResult.Complete -> {
+                    val accessToken = accessTokenResult.resultValue.accessToken
+                    binding.resultAccessToken.text = getString(R.string.result_access_token_text) + accessToken
 
-                val idToken = accountState.getIdToken()
-                binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
+                    val idToken = accountState.getIdToken()
+                    binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
+                }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage.toString())
+                }
+                else -> {
+                    displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())
+                }
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MainActivity.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.ActivityMainBinding
-import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
 
@@ -28,7 +27,7 @@ class MainActivity : AppCompatActivity() {
 
         setCurrentFragment(emailSignInSignUpFragment, R.string.title_email_oob_sisu)
 
-        bottom_navigation_view.setOnNavigationItemSelectedListener {
+        binding.bottomNavigationView.setOnNavigationItemSelectedListener {
             when (it.itemId) {
                 R.id.email_oob_sisu -> setCurrentFragment(emailSignInSignUpFragment, R.string.title_email_oob_sisu)
                 R.id.email_password_sisu -> setCurrentFragment(emailPasswordSignInSignUpFragment, R.string.title_email_password_sisu)

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetCodeFragment.kt
@@ -84,7 +84,7 @@ class PasswordResetCodeFragment : Fragment() {
                     Toast.makeText(requireContext(), getString(R.string.resend_code_message), Toast.LENGTH_LONG).show()
                 }
                 is ResendCodeError -> {
-                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
                 }
             }
         }
@@ -101,7 +101,7 @@ class PasswordResetCodeFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetCodeFragment.kt
@@ -72,7 +72,7 @@ class PasswordResetCodeFragment : Fragment() {
                     handleError(actionResult)
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message.toString())
+                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.errorMessage)
                 }
             }
         }
@@ -93,7 +93,7 @@ class PasswordResetCodeFragment : Fragment() {
                     displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetCodeFragment.kt
@@ -6,11 +6,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentCodeBinding
-import com.microsoft.identity.client.exception.MsalException
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordCodeRequiredState
 import com.microsoft.identity.nativeauth.statemachine.errors.ResendCodeError
 import com.microsoft.identity.nativeauth.statemachine.errors.SubmitCodeError
@@ -71,9 +68,6 @@ class PasswordResetCodeFragment : Fragment() {
                 is SubmitCodeError -> {
                     handleError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -90,10 +84,7 @@ class PasswordResetCodeFragment : Fragment() {
                     Toast.makeText(requireContext(), getString(R.string.resend_code_message), Toast.LENGTH_LONG).show()
                 }
                 is ResendCodeError -> {
-                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
-                }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
+                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
                 }
             }
         }
@@ -110,7 +101,7 @@ class PasswordResetCodeFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
@@ -9,8 +9,8 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailSsprBinding
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccountError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
@@ -72,8 +72,8 @@ class PasswordResetFragment : Fragment() {
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
+                is GetAccountError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailSsprBinding
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
@@ -94,9 +95,6 @@ class PasswordResetFragment : Fragment() {
                 is ResetPasswordError -> {
                     handleError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -165,11 +163,8 @@ class PasswordResetFragment : Fragment() {
                     val idToken = accountState.getIdToken()
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
-                }
-                else -> {
-                    displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())
+                is GetAccessTokenError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message ?: accessTokenResult.errorMessage)
                 }
             }
         }
@@ -182,7 +177,7 @@ class PasswordResetFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
@@ -157,13 +157,20 @@ class PasswordResetFragment : Fragment() {
     private fun displayAccount(accountState: AccountState) {
         CoroutineScope(Dispatchers.Main).launch {
             val accessTokenResult = accountState.getAccessToken()
-            if (accessTokenResult is GetAccessTokenResult.Complete) {
-                val accessToken = accessTokenResult.resultValue.accessToken
-                binding.resultAccessToken.text =
-                    getString(R.string.result_access_token_text) + accessToken
+            when (accessTokenResult) {
+                is GetAccessTokenResult.Complete -> {
+                    val accessToken = accessTokenResult.resultValue.accessToken
+                    binding.resultAccessToken.text = getString(R.string.result_access_token_text) + accessToken
 
-                val idToken = accountState.getIdToken()
-                binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
+                    val idToken = accountState.getIdToken()
+                    binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
+                }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage.toString())
+                }
+                else -> {
+                    displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())
+                }
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
@@ -72,7 +72,7 @@ class PasswordResetFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }
@@ -95,7 +95,7 @@ class PasswordResetFragment : Fragment() {
                     handleError(actionResult)
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
                 }
             }
         }
@@ -166,7 +166,7 @@ class PasswordResetFragment : Fragment() {
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage.toString())
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
                 }
                 else -> {
                     displayDialog(getString(R.string.unexpected_sdk_result_title), accessTokenResult.toString())

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetFragment.kt
@@ -73,7 +73,7 @@ class PasswordResetFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is GetAccountError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }
@@ -164,7 +164,7 @@ class PasswordResetFragment : Fragment() {
                     binding.resultIdToken.text = getString(R.string.result_id_token_text) + idToken
                 }
                 is GetAccessTokenError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.exception?.message ?: accessTokenResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accessTokenResult.errorMessage)
                 }
             }
         }
@@ -177,7 +177,7 @@ class PasswordResetFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
@@ -84,7 +84,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
                     handleError(actionResult)
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
                 }
             }
         }
@@ -106,10 +106,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
                 displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
             }
             is ClientExceptionError -> {
-                displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
-            }
-            else -> {
-                displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
+                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
@@ -6,14 +6,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.text.set
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentPasswordBinding
-import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.common.java.util.StringUtil
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordSubmitPasswordError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
 import com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordResult
@@ -83,9 +80,6 @@ class PasswordResetNewPasswordFragment : Fragment() {
                 is ResetPasswordSubmitPasswordError -> {
                     handleError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -103,10 +97,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
                 finish()
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
-            }
-            is ClientExceptionError -> {
-                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
             }
         }
     }
@@ -118,7 +109,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
@@ -58,13 +58,9 @@ class PasswordResetNewPasswordFragment : Fragment() {
             val password = CharArray(binding.passwordText.length())
             binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
 
-            val actionResult: ResetPasswordSubmitPasswordResult
-            try {
-                actionResult = currentState.submitPassword(password)
-            } finally {
-                binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
-                StringUtil.overwriteWithNull(password)
-            }
+            val actionResult: ResetPasswordSubmitPasswordResult = currentState.submitPassword(password)
+            binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
+            StringUtil.overwriteWithNull(password)
 
             when (actionResult) {
                 is ResetPasswordResult.Complete -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
@@ -6,12 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.core.text.set
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentPasswordBinding
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.common.java.util.StringUtil
+import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordSubmitPasswordError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
 import com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordResult
@@ -56,35 +58,34 @@ class PasswordResetNewPasswordFragment : Fragment() {
 
     private fun resetPassword() {
         CoroutineScope(Dispatchers.Main).launch {
+            val password = CharArray(binding.passwordText.length())
+            binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
+
+            val actionResult: ResetPasswordSubmitPasswordResult
             try {
-                val password = CharArray(binding.passwordText.length())
-                binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
+                actionResult = currentState.submitPassword(password)
+            } finally {
+                binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
+                StringUtil.overwriteWithNull(password)
+            }
 
-                val actionResult: ResetPasswordSubmitPasswordResult
-                try {
-                    actionResult = currentState.submitPassword(password)
-                } finally {
-                    binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
-                    StringUtil.overwriteWithNull(password)
+            when (actionResult) {
+                is ResetPasswordResult.Complete -> {
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.password_reset_success_message),
+                        Toast.LENGTH_LONG
+                    ).show()
+                    signInAfterPasswordReset(
+                        nextState = actionResult.nextState
+                    )
                 }
-
-                when (actionResult) {
-                    is ResetPasswordResult.Complete -> {
-                        Toast.makeText(
-                            requireContext(),
-                            getString(R.string.password_reset_success_message),
-                            Toast.LENGTH_LONG
-                        ).show()
-                        signInAfterPasswordReset(
-                            nextState = actionResult.nextState
-                        )
-                    }
-                    is ResetPasswordSubmitPasswordError -> {
-                        handleError(actionResult)
-                    }
+                is ResetPasswordSubmitPasswordError -> {
+                    handleError(actionResult)
                 }
-            } catch (exception: MsalException) {
-                displayDialog(getString(R.string.msal_exception_title), exception.message.toString())
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                }
             }
         }
     }
@@ -103,6 +104,9 @@ class PasswordResetNewPasswordFragment : Fragment() {
             }
             is SignInContinuationError -> {
                 displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
+            }
+            is ClientExceptionError -> {
+                displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
             }
             else -> {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
@@ -97,7 +97,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
                 finish()
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
+                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
             }
         }
     }
@@ -109,7 +109,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
@@ -10,6 +10,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentCodeBinding
 import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResendCodeError
 import com.microsoft.identity.nativeauth.statemachine.errors.SubmitCodeError
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResendCodeResult
@@ -72,6 +73,9 @@ class SignInCodeFragment : Fragment() {
                     is SubmitCodeError -> {
                         handleSubmitCodeError(actionResult)
                     }
+                    is ClientExceptionError -> {
+                        displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                    }
                 }
             } catch (exception: MsalException) {
                 displayDialog(getString(R.string.msal_exception_title), exception.message.toString())
@@ -92,6 +96,9 @@ class SignInCodeFragment : Fragment() {
                 }
                 is ResendCodeError -> {
                     displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
+                }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentCodeBinding
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResendCodeError
 import com.microsoft.identity.nativeauth.statemachine.errors.SubmitCodeError
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResendCodeResult
@@ -70,9 +69,6 @@ class SignInCodeFragment : Fragment() {
                 is SubmitCodeError -> {
                     handleSubmitCodeError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -89,10 +85,7 @@ class SignInCodeFragment : Fragment() {
                     Toast.makeText(requireContext(), getString(R.string.resend_code_message), Toast.LENGTH_LONG).show()
                 }
                 is ResendCodeError -> {
-                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
-                }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
+                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
@@ -85,7 +85,7 @@ class SignInCodeFragment : Fragment() {
                     Toast.makeText(requireContext(), getString(R.string.resend_code_message), Toast.LENGTH_LONG).show()
                 }
                 is ResendCodeError -> {
-                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
+                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
@@ -2,14 +2,12 @@ package com.azuresamples.msalnativeauthandroidkotlinsampleapp
 
 import android.app.AlertDialog
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentCodeBinding
-import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResendCodeError
 import com.microsoft.identity.nativeauth.statemachine.errors.SubmitCodeError

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignInCodeFragment.kt
@@ -56,29 +56,25 @@ class SignInCodeFragment : Fragment() {
 
     private fun verifyCode() {
         CoroutineScope(Dispatchers.Main).launch {
-            try {
-                val emailCode = binding.codeText.text.toString()
+            val emailCode = binding.codeText.text.toString()
 
-                val actionResult = currentState.submitCode(emailCode)
+            val actionResult = currentState.submitCode(emailCode)
 
-                when (actionResult) {
-                    is SignInResult.Complete -> {
-                        Toast.makeText(
-                            requireContext(),
-                            getString(R.string.sign_in_successful_message),
-                            Toast.LENGTH_SHORT
-                        ).show()
-                        finish()
-                    }
-                    is SubmitCodeError -> {
-                        handleSubmitCodeError(actionResult)
-                    }
-                    is ClientExceptionError -> {
-                        displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
-                    }
+            when (actionResult) {
+                is SignInResult.Complete -> {
+                    Toast.makeText(
+                        requireContext(),
+                        getString(R.string.sign_in_successful_message),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    finish()
                 }
-            } catch (exception: MsalException) {
-                displayDialog(getString(R.string.msal_exception_title), exception.message.toString())
+                is SubmitCodeError -> {
+                    handleSubmitCodeError(actionResult)
+                }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
+                }
             }
         }
     }
@@ -98,7 +94,7 @@ class SignInCodeFragment : Fragment() {
                     displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
@@ -77,7 +77,7 @@ class SignUpCodeFragment : Fragment() {
                     handleSubmitError(actionResult)
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
                 }
             }
         }
@@ -103,7 +103,7 @@ class SignUpCodeFragment : Fragment() {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
             }
             is ClientExceptionError -> {
-                displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
             }
         }
     }
@@ -123,7 +123,7 @@ class SignUpCodeFragment : Fragment() {
                     displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
@@ -9,6 +9,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentCodeBinding
 import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResendCodeError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
 import com.microsoft.identity.nativeauth.statemachine.errors.SubmitCodeError
@@ -57,28 +58,27 @@ class SignUpCodeFragment : Fragment() {
 
     private fun verifyCode() {
         CoroutineScope(Dispatchers.Main).launch {
-            try {
-                val oobCode = binding.codeText.text.toString()
+            val oobCode = binding.codeText.text.toString()
 
-                val actionResult = currentState.submitCode(oobCode)
+            val actionResult = currentState.submitCode(oobCode)
 
-                when (actionResult) {
-                    is SignUpResult.Complete -> {
-                        Toast.makeText(requireContext(), getString(R.string.sign_up_successful_message), Toast.LENGTH_SHORT).show()
-                        signInAfterSignUp(
-                            nextState = actionResult.nextState
-                        )
-                    }
-                    is SignUpResult.AttributesRequired,
-                    is SignUpResult.PasswordRequired -> {
-                        displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
-                    }
-                    is SubmitCodeError -> {
-                        handleSubmitError(actionResult)
-                    }
+            when (actionResult) {
+                is SignUpResult.Complete -> {
+                    Toast.makeText(requireContext(), getString(R.string.sign_up_successful_message), Toast.LENGTH_SHORT).show()
+                    signInAfterSignUp(
+                        nextState = actionResult.nextState
+                    )
                 }
-            } catch (exception: MsalException) {
-                displayDialog(getString(R.string.msal_exception_title), exception.message.toString())
+                is SignUpResult.AttributesRequired,
+                is SignUpResult.PasswordRequired -> {
+                    displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
+                }
+                is SubmitCodeError -> {
+                    handleSubmitError(actionResult)
+                }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                }
             }
         }
     }
@@ -102,6 +102,9 @@ class SignUpCodeFragment : Fragment() {
             is SignInResult.PasswordRequired -> {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
             }
+            is ClientExceptionError -> {
+                displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+            }
         }
     }
 
@@ -109,20 +112,19 @@ class SignUpCodeFragment : Fragment() {
         clearCode()
 
         CoroutineScope(Dispatchers.Main).launch {
-            try {
-                val actionResult = currentState.resendCode()
+            val actionResult = currentState.resendCode()
 
-                when (actionResult) {
-                    is SignUpResendCodeResult.Success -> {
-                        currentState = actionResult.nextState
-                        Toast.makeText(requireContext(), getString(R.string.resend_code_message), Toast.LENGTH_LONG).show()
-                    }
-                    is ResendCodeError -> {
-                        displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
-                    }
+            when (actionResult) {
+                is SignUpResendCodeResult.Success -> {
+                    currentState = actionResult.nextState
+                    Toast.makeText(requireContext(), getString(R.string.resend_code_message), Toast.LENGTH_LONG).show()
                 }
-            } catch (exception: MsalException) {
-                displayDialog(getString(R.string.msal_exception_title), exception.message.toString())
+                is ResendCodeError -> {
+                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
+                }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), actionResult.exception?.message.toString())
+                }
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
@@ -8,8 +8,6 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentCodeBinding
-import com.microsoft.identity.client.exception.MsalException
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResendCodeError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
 import com.microsoft.identity.nativeauth.statemachine.errors.SubmitCodeError
@@ -76,9 +74,6 @@ class SignUpCodeFragment : Fragment() {
                 is SubmitCodeError -> {
                     handleSubmitError(actionResult)
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
-                }
             }
         }
     }
@@ -96,14 +91,11 @@ class SignUpCodeFragment : Fragment() {
                 finish()
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
             }
             is SignInResult.CodeRequired,
             is SignInResult.PasswordRequired -> {
                 displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
-            }
-            is ClientExceptionError -> {
-                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
             }
         }
     }
@@ -120,10 +112,7 @@ class SignUpCodeFragment : Fragment() {
                     Toast.makeText(requireContext(), getString(R.string.resend_code_message), Toast.LENGTH_LONG).show()
                 }
                 is ResendCodeError -> {
-                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.toString())
-                }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
+                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
                 }
             }
         }
@@ -140,7 +129,7 @@ class SignUpCodeFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.toString())
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
@@ -91,7 +91,7 @@ class SignUpCodeFragment : Fragment() {
                 finish()
             }
             is SignInContinuationError -> {
-                displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
+                displayDialog(getString(R.string.msal_exception_title), actionResult.errorMessage)
             }
             is SignInResult.CodeRequired,
             is SignInResult.PasswordRequired -> {
@@ -112,7 +112,7 @@ class SignUpCodeFragment : Fragment() {
                     Toast.makeText(requireContext(), getString(R.string.resend_code_message), Toast.LENGTH_LONG).show()
                 }
                 is ResendCodeError -> {
-                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.exception?.message ?: actionResult.errorMessage)
+                    displayDialog(getString(R.string.unexpected_sdk_error_title), actionResult.errorMessage)
                 }
             }
         }
@@ -129,7 +129,7 @@ class SignUpCodeFragment : Fragment() {
             }
             else -> {
                 // Unexpected error
-                displayDialog(getString(R.string.unexpected_sdk_error_title), error.exception?.message ?: error.errorMessage)
+                displayDialog(getString(R.string.unexpected_sdk_error_title), error.errorMessage)
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
@@ -78,7 +78,7 @@ class WebFallbackFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is GetAccountError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
@@ -78,7 +78,7 @@ class WebFallbackFragment : Fragment() {
                     displaySignedOutState()
                 }
                 is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message.toString())
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
@@ -18,7 +18,7 @@ import com.microsoft.identity.client.IAuthenticationResult
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
-import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAccountError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResult
@@ -77,8 +77,8 @@ class WebFallbackFragment : Fragment() {
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
                 }
-                is ClientExceptionError -> {
-                    displayDialog(getString(R.string.msal_exception_title), accountResult.errorMessage)
+                is GetAccountError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message ?: accountResult.errorMessage)
                 }
             }
         }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
@@ -90,20 +90,16 @@ class WebFallbackFragment : Fragment() {
             val password = CharArray(binding.passwordText.length())
             binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
 
-            val actionResult: SignInResult
-            try {
-                actionResult = authClient.signIn(
-                    username = email,
-                    password = password
-                )
-            } finally {
-                binding.passwordText.text?.set(
-                    0,
-                    binding.passwordText.text?.length?.minus(1) ?: 0,
-                    0
-                )
-                StringUtil.overwriteWithNull(password)
-            }
+            val actionResult: SignInResult = authClient.signIn(
+                username = email,
+                password = password
+            )
+            binding.passwordText.text?.set(
+                0,
+                binding.passwordText.text?.length?.minus(1) ?: 0,
+                0
+            )
+            StringUtil.overwriteWithNull(password)
 
             if (actionResult is SignInError && actionResult.isBrowserRequired()) {
                 Toast.makeText(requireContext(), actionResult.errorMessage, Toast.LENGTH_SHORT)

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
@@ -18,6 +18,7 @@ import com.microsoft.identity.client.IAuthenticationResult
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
+import com.microsoft.identity.nativeauth.statemachine.errors.ClientExceptionError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResult
@@ -76,50 +77,48 @@ class WebFallbackFragment : Fragment() {
                 is GetAccountResult.NoAccountFound -> {
                     displaySignedOutState()
                 }
+                is ClientExceptionError -> {
+                    displayDialog(getString(R.string.msal_exception_title), accountResult.exception?.message.toString())
+                }
             }
         }
     }
 
     private fun signIn() {
         CoroutineScope(Dispatchers.Main).launch {
+            val email = binding.emailText.text.toString()
+            val password = CharArray(binding.passwordText.length())
+            binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
+
+            val actionResult: SignInResult
             try {
-                val email = binding.emailText.text.toString()
-                val password = CharArray(binding.passwordText.length())
-                binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
+                actionResult = authClient.signIn(
+                    username = email,
+                    password = password
+                )
+            } finally {
+                binding.passwordText.text?.set(
+                    0,
+                    binding.passwordText.text?.length?.minus(1) ?: 0,
+                    0
+                )
+                StringUtil.overwriteWithNull(password)
+            }
 
-                val actionResult: SignInResult
-                try {
-                    actionResult = authClient.signIn(
-                        username = email,
-                        password = password
-                    )
-                } finally {
-                    binding.passwordText.text?.set(
-                        0,
-                        binding.passwordText.text?.length?.minus(1) ?: 0,
-                        0
-                    )
-                    StringUtil.overwriteWithNull(password)
-                }
+            if (actionResult is SignInError && actionResult.isBrowserRequired()) {
+                Toast.makeText(requireContext(), actionResult.errorMessage, Toast.LENGTH_SHORT)
+                    .show()
 
-                if (actionResult is SignInError && actionResult.isBrowserRequired()) {
-                    Toast.makeText(requireContext(), actionResult.errorMessage, Toast.LENGTH_SHORT)
-                        .show()
-
-                    authClient.acquireToken(
-                        AcquireTokenParameters(
-                            AcquireTokenParameters.Builder()
-                                .startAuthorizationFromActivity(requireActivity())
-                                .withScopes(mutableListOf("profile", "openid", "email"))
-                                .withCallback(getAuthInteractiveCallback())
-                        )
+                authClient.acquireToken(
+                    AcquireTokenParameters(
+                        AcquireTokenParameters.Builder()
+                            .startAuthorizationFromActivity(requireActivity())
+                            .withScopes(mutableListOf("profile", "openid", "email"))
+                            .withCallback(getAuthInteractiveCallback())
                     )
-                } else {
+                )
+            } else {
                     displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
-                }
-
-            } catch (exception: MsalException) {
-                displayDialog(getString(R.string.msal_exception_title), exception.message.toString())
             }
         }
     }


### PR DESCRIPTION
Change summary:
- Use corresponding errors instead of try catch block in sample app.
- Use error.exception?.message ?: error.errorMessage instead of error.toString() in dialogue
- https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2883053 include this bug fixing into this PR.

Company PRs:
msal: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2080
