### PR TITLE
Multiple access token sample update proposal

### DIFF
--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -52,12 +52,9 @@ class AccessApiFragment : Fragment() {
 
         init()
 
-        return binding.root
-    }
-
-    override fun onResume() {
-        super.onResume()
         getStateAndUpdateUI()
+
+        return binding.root
     }
 
     private fun init() {
@@ -240,11 +237,11 @@ class AccessApiFragment : Fragment() {
         binding.resultText.text = ""
     }
 
-    private fun displayAccount(accountState: AccountState, scopes: List<String> = listOf("openid", "offline_access", "profile") ) {  // The default scopes added by the SDK
+    private fun displayAccount(accountState: AccountState) {
         CoroutineScope(Dispatchers.Main).launch {
-            val accessToken = getAccessToken(accountState, scopes)
-            binding.result.text = getString(R.string.result_access_token_of_scopes_text)  + scopes.toString()
-            binding.resultText.text = accessToken
+            val username = accountState.getAccount().username
+            binding.result.text = getString(R.string.result_account_text)
+            binding.resultText.text = username
         }
     }
 

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -34,10 +34,11 @@ class AccessApiFragment : Fragment() {
     companion object {
         private val TAG = AccessApiFragment::class.java.simpleName
         private enum class STATUS { SignedIn, SignedOut }
-        private const val WEB_API_BASE_URL_1 = "" // Developers should set the first respective URL of their web API here
-        private const val WEB_API_BASE_URL_2 = "" // Developers should set the second respective URL of their web API here
-        private val scopesForAPI1 = listOf<String>() // Developers should set the first respective scopes of their web API here
-        private val scopesForAPI2 = listOf<String>() // Developers should set the second respective scopes of their web API here
+        private const val WEB_API_BASE_URL_1 = "" // Developers should set the first respective URL of their web API resource here
+        private const val WEB_API_BASE_URL_2 = "" // Developers should set the second respective URL of their web API resource here
+        // Developers should set the respective scopes for their web API resources here, for example: ["api://<Resource_App_ID>/ToDoList.Read", "api://<Resource_App_ID>/ToDoList.ReadWrite"]
+        private val scopesForAPI1 = listOf<String>()
+        private val scopesForAPI2 = listOf<String>()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -237,7 +238,7 @@ class AccessApiFragment : Fragment() {
         binding.resultText.text = ""
     }
 
-    private fun displayAccount(accountState: AccountState, scopes: List<String> = listOf("openid", "offline_access", "profile") ) {
+    private fun displayAccount(accountState: AccountState, scopes: List<String> = listOf("openid", "offline_access", "profile") ) {  // The default scopes added by the SDK
         CoroutineScope(Dispatchers.Main).launch {
             val accessToken = getAccessToken(accountState, scopes)
             binding.result.text = getString(R.string.result_access_token_of_scopes_text)  + scopes.toString()

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContentProviderCompat.requireContext
@@ -33,10 +34,10 @@ class AccessApiFragment : Fragment() {
     companion object {
         private val TAG = AccessApiFragment::class.java.simpleName
         private enum class STATUS { SignedIn, SignedOut }
-        private const val WEB_API_BASE_URL_1 = "" // Developers should set the respective URL of their web API here
-        private const val WEB_API_BASE_URL_2 = "" // Developers should set the respective URL of their web API here
-        private val scopesForAPI1 = listOf<String>() // Developers should set the respective scopes of their web API here
-        private val scopesForAPI2 = listOf<String>() // Developers should set the respective scopes of their web API here
+        private const val WEB_API_BASE_URL_1 = "" // Developers should set the first respective URL of their web API here
+        private const val WEB_API_BASE_URL_2 = "" // Developers should set the second respective URL of their web API here
+        private val scopesForAPI1 = listOf<String>() // Developers should set the first respective scopes of their web API here
+        private val scopesForAPI2 = listOf<String>() // Developers should set the second respective scopes of their web API here
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -65,8 +66,12 @@ class AccessApiFragment : Fragment() {
             signIn()
         }
 
-        binding.getApi.setOnClickListener {
-            accessWebAPI()
+        binding.getApi1.setOnClickListener {
+            accessWebAPIAndUpdateUI(WEB_API_BASE_URL_1, scopesForAPI1, binding.resultText1)
+        }
+
+        binding.getApi2.setOnClickListener {
+            accessWebAPIAndUpdateUI(WEB_API_BASE_URL_2, scopesForAPI2, binding.resultText2)
         }
 
         binding.signOut.setOnClickListener {
@@ -164,8 +169,8 @@ class AccessApiFragment : Fragment() {
         }
     }
 
-    private fun accessWebAPI() {
-        if (WEB_API_BASE_URL_1.isBlank() and WEB_API_BASE_URL_2.isBlank()) {
+    private fun accessWebAPIAndUpdateUI(baseUrl: String, scopes: List<String>, textField: TextView) {
+        if (baseUrl.isBlank()) {
             displayDialog(getString(R.string.invalid_web_url_title), getString(R.string.invalid_web_url_message))
             return
         }
@@ -175,12 +180,9 @@ class AccessApiFragment : Fragment() {
             when (accountResult) {
                 is GetAccountResult.AccountFound -> {
                     try {
-                        val accessToken1 = getAccessToken(accountResult.resultValue, scopesForAPI1)
-                        val apiResponse1 = useAccessToken(WEB_API_BASE_URL_1, accessToken1)
-                        binding.resultText1.text = getString(R.string.response_api) + apiResponse1.toString()
-                        val accessToken2 = getAccessToken(accountResult.resultValue, scopesForAPI1)
-                        val apiResponse2 = useAccessToken(WEB_API_BASE_URL_2, accessToken2)
-                        binding.resultText2.text = getString(R.string.response_api) + apiResponse2.toString()
+                        val accessToken = getAccessToken(accountResult.resultValue, scopes)
+                        val apiResponse = useAccessToken(WEB_API_BASE_URL_1, accessToken)
+                        textField.text = getString(R.string.response_api) + apiResponse.toString()
                     } catch (e: Exception) {
                         displayDialog(getString(R.string.network_request_exception_titile), e.message ?: getString(R.string.unknown_error_message))
                     }
@@ -219,12 +221,14 @@ class AccessApiFragment : Fragment() {
             STATUS.SignedIn -> {
                 binding.signIn.isEnabled = false
                 binding.signOut.isEnabled = true
-                binding.getApi.isEnabled = true
+                binding.getApi1.isEnabled = true
+                binding.getApi2.isEnabled = true
             }
             STATUS.SignedOut -> {
                 binding.signIn.isEnabled = true
                 binding.signOut.isEnabled = false
-                binding.getApi.isEnabled = false
+                binding.getApi1.isEnabled = false
+                binding.getApi2.isEnabled = true
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -180,6 +180,7 @@ class AccessApiFragment : Fragment() {
                     try {
                         val accessToken = getAccessToken(accountResult.resultValue, scopes)
                         val apiResponse = useAccessToken(baseUrl, accessToken)
+                        binding.result.text = getString(R.string.result_access_token_of_scopes_text)  + scopes.toString()
                         binding.resultText.text = getString(R.string.response_api) + apiResponse.toString()
                     } catch (e: Exception) {
                         displayDialog(getString(R.string.network_request_exception_titile), e.message ?: getString(R.string.unknown_error_message))
@@ -232,12 +233,14 @@ class AccessApiFragment : Fragment() {
     }
 
     private fun emptyResults() {
+        binding.result.text = ""
         binding.resultText.text = ""
     }
 
-    private fun displayAccount(accountState: AccountState, scopes: List<String> = emptyList()) {
+    private fun displayAccount(accountState: AccountState, scopes: List<String> = listOf("openid", "offline_access", "profile") ) {
         CoroutineScope(Dispatchers.Main).launch {
             val accessToken = getAccessToken(accountState, scopes)
+            binding.result.text = getString(R.string.result_access_token_of_scopes_text)  + scopes.toString()
             binding.resultText.text = accessToken
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -5,10 +5,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentAccessApiBinding
 import com.microsoft.identity.client.exception.MsalException
@@ -38,8 +36,8 @@ class AccessApiFragment : Fragment() {
     companion object {
         private val TAG = AccessApiFragment::class.java.simpleName
         private enum class STATUS { SignedIn, SignedOut }
-        private const val WEB_API_BASE_URL_1 = "" // Developers should set the first respective URL of their web API resource here
-        private const val WEB_API_BASE_URL_2 = "" // Developers should set the second respective URL of their web API resource here
+        private const val WEB_API_URL_1 = "" // Developers should set the URL of their first web API resource here
+        private const val WEB_API_URL_2 = "" // Developers should set the URL of their second web API resource here
         // Developers should set the respective scopes for their web API resources here, for example: ["api://<Resource_App_ID>/ToDoList.Read", "api://<Resource_App_ID>/ToDoList.ReadWrite"]
         private val scopesForAPI1 = listOf<String>()
         private val scopesForAPI2 = listOf<String>()
@@ -72,11 +70,11 @@ class AccessApiFragment : Fragment() {
         }
 
         binding.getApi1.setOnClickListener {
-            accessWebAPIAndUpdateUI(WEB_API_BASE_URL_1, scopesForAPI1)
+            accessWebAPIAndUpdateUI(WEB_API_URL_1, scopesForAPI1)
         }
 
         binding.getApi2.setOnClickListener {
-            accessWebAPIAndUpdateUI(WEB_API_BASE_URL_2, scopesForAPI2)
+            accessWebAPIAndUpdateUI(WEB_API_URL_2, scopesForAPI2)
         }
 
         binding.signOut.setOnClickListener {
@@ -166,14 +164,14 @@ class AccessApiFragment : Fragment() {
         }
     }
 
-    private suspend fun useAccessToken(WEB_API_BASE_URL: String, accessToken: String): Response {
+    private suspend fun useAccessToken(WEB_API_URL: String, accessToken: String): Response {
         return withContext(Dispatchers.IO) {
-            ApiClient.performGetApiRequest(WEB_API_BASE_URL, accessToken)
+            ApiClient.performGetApiRequest(WEB_API_URL, accessToken)
         }
     }
 
-    private fun accessWebAPIAndUpdateUI(baseUrl: String, scopes: List<String>) {
-        if (baseUrl.isBlank()) {
+    private fun accessWebAPIAndUpdateUI(webApiUrl: String, scopes: List<String>) {
+        if (webApiUrl.isBlank()) {
             displayDialog(getString(R.string.invalid_web_url_title), getString(R.string.invalid_web_url_message))
             return
         }
@@ -184,7 +182,7 @@ class AccessApiFragment : Fragment() {
                 is GetAccountResult.AccountFound -> {
                     try {
                         val accessToken = getAccessToken(accountResult.resultValue, scopes)
-                        val apiResponse = useAccessToken(baseUrl, accessToken)
+                        val apiResponse = useAccessToken(webApiUrl, accessToken)
                         binding.result.text = getString(R.string.result_access_token_of_scopes_text)  + scopes.toString()
                         binding.resultText.text = getString(R.string.response_api) + apiResponse.toString()
                     } catch (e: Exception) {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -26,6 +26,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.Response
 
+/**
+ * AccessApiFragment class implements samples for accessing custom web APIs using Entra External ID identity tokens.
+ * Learn documentation: https://learn.microsoft.com/en-us/entra/external-id/customers/sample-native-authentication-android-sample-app-call-web-api
+ */
 class AccessApiFragment : Fragment() {
     private lateinit var authClient: INativeAuthPublicClientApplication
     private var _binding: FragmentAccessApiBinding? = null

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -228,7 +228,7 @@ class AccessApiFragment : Fragment() {
                 binding.signIn.isEnabled = true
                 binding.signOut.isEnabled = false
                 binding.getApi1.isEnabled = false
-                binding.getApi2.isEnabled = true
+                binding.getApi2.isEnabled = false
             }
         }
     }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/ApiClient.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/ApiClient.kt
@@ -8,8 +8,8 @@ import okhttp3.Response
 object ApiClient {
     private val client = OkHttpClient()
 
-    fun performGetApiRequest(WEB_API_BASE_URL: String, accessToken: String): Response {
-        val fullUrl = "$WEB_API_BASE_URL/api/todolist"
+    fun performGetApiRequest(WEB_API_URL: String, accessToken: String): Response {
+        val fullUrl = "$WEB_API_URL/api/todolist"
 
         val requestBuilder = Request.Builder()
                 .url(fullUrl)

--- a/app/src/main/res/layout/fragment_access_api.xml
+++ b/app/src/main/res/layout/fragment_access_api.xml
@@ -119,7 +119,7 @@
             app:layout_constraintTop_toBottomOf="@+id/get_api" />
 
         <TextView
-            android:id="@+id/result_text"
+            android:id="@+id/result_text_1"
             style="@style/TextViewStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -129,6 +129,18 @@
             android:text=""
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/result"/>
+
+        <TextView
+            android:id="@+id/result_text_2"
+            style="@style/TextViewStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="@dimen/dimens_15dp"
+            android:paddingEnd="@dimen/dimens_15dp"
+            android:paddingTop="@dimen/dimens_5dp"
+            android:text=""
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/result_text_1"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_access_api.xml
+++ b/app/src/main/res/layout/fragment_access_api.xml
@@ -129,7 +129,7 @@
             app:layout_constraintTop_toBottomOf="@+id/get_api_2" />
 
         <TextView
-            android:id="@+id/result_text_1"
+            android:id="@+id/result_text"
             style="@style/TextViewStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -139,19 +139,6 @@
             android:text=""
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/result"/>
-
-        <TextView
-            android:id="@+id/result_text_2"
-            style="@style/TextViewStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingStart="@dimen/dimens_15dp"
-            android:paddingEnd="@dimen/dimens_15dp"
-            android:paddingTop="@dimen/dimens_5dp"
-            android:text=""
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/result_text_1"/>
-
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </ScrollView>

--- a/app/src/main/res/layout/fragment_access_api.xml
+++ b/app/src/main/res/layout/fragment_access_api.xml
@@ -99,14 +99,24 @@
             style="@style/ActionButtonStyle" />
 
         <Button
-            android:id="@+id/get_api"
+            android:id="@+id/get_api_1"
             style="@style/ActionButtonStyle"
             android:layout_marginTop="@dimen/dimens_15dp"
             android:enabled="false"
-            android:text="@string/api_get"
+            android:text="API 1 - Perform GET"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/sign_out" />
+
+        <Button
+            android:id="@+id/get_api_2"
+            style="@style/ActionButtonStyle"
+            android:layout_marginTop="@dimen/dimens_15dp"
+            android:enabled="false"
+            android:text="API 2 - Perform GET"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/get_api_1" />
 
         <TextView
             android:id="@+id/result"
@@ -116,7 +126,7 @@
             android:layout_marginTop="@dimen/dimens_15dp"
             android:text="@string/result_access_token_text"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/get_api" />
+            app:layout_constraintTop_toBottomOf="@+id/get_api_2" />
 
         <TextView
             android:id="@+id/result_text_1"

--- a/app/src/main/res/layout/fragment_more.xml
+++ b/app/src/main/res/layout/fragment_more.xml
@@ -42,43 +42,4 @@
 		android:background="?android:attr/listDivider"
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintTop_toBottomOf="@+id/use_access_token" />
-
-	<Button
-		android:id="@+id/access_graph_api"
-		android:layout_marginTop="@dimen/dimens_15dp"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"
-		android:text="Access Microsoft Graph API"
-		app:layout_constraintStart_toStartOf="parent"
-		app:layout_constraintTop_toBottomOf="@+id/divider2"
-		style="@style/OptionItemStyle" />
-
-	<View
-		android:id="@+id/divider3"
-		android:layout_width="match_parent"
-		android:layout_height="@dimen/dimens_1dp"
-		android:layout_marginLeft="@dimen/dimens_10dp"
-		android:background="?android:attr/listDivider"
-		app:layout_constraintStart_toStartOf="parent"
-		app:layout_constraintTop_toBottomOf="@+id/access_graph_api" />
-
-	<Button
-		android:id="@+id/access_multiple_api"
-		android:layout_marginTop="@dimen/dimens_15dp"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"
-		android:text="Access Multiple APIs"
-		app:layout_constraintStart_toStartOf="parent"
-		app:layout_constraintTop_toBottomOf="@+id/divider3"
-		style="@style/OptionItemStyle" />
-
-	<View
-		android:id="@+id/divider4"
-		android:layout_width="match_parent"
-		android:layout_height="@dimen/dimens_1dp"
-		android:layout_marginLeft="@dimen/dimens_10dp"
-		android:background="?android:attr/listDivider"
-		app:layout_constraintStart_toStartOf="parent"
-		app:layout_constraintTop_toBottomOf="@+id/access_multiple_api" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_more.xml
+++ b/app/src/main/res/layout/fragment_more.xml
@@ -10,7 +10,7 @@
         android:layout_marginTop="@dimen/dimens_15dp"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:text="Web Fallback"
+        android:text="@string/title_web_fallback"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         style="@style/OptionItemStyle" />
@@ -29,7 +29,7 @@
 		android:layout_marginTop="@dimen/dimens_15dp"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="Access Custom Protected API"
+		android:text="@string/title_access_web_api"
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintTop_toBottomOf="@+id/divider1"
 		style="@style/OptionItemStyle" />

--- a/app/src/main/res/layout/fragment_more.xml
+++ b/app/src/main/res/layout/fragment_more.xml
@@ -29,7 +29,7 @@
 		android:layout_marginTop="@dimen/dimens_15dp"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:text="Access Protected API"
+		android:text="Access Custom Protected API"
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintTop_toBottomOf="@+id/divider1"
 		style="@style/OptionItemStyle" />
@@ -42,5 +42,43 @@
 		android:background="?android:attr/listDivider"
 		app:layout_constraintStart_toStartOf="parent"
 		app:layout_constraintTop_toBottomOf="@+id/use_access_token" />
+
+	<Button
+		android:id="@+id/access_graph_api"
+		android:layout_marginTop="@dimen/dimens_15dp"
+		android:layout_width="fill_parent"
+		android:layout_height="wrap_content"
+		android:text="Access Microsoft Graph API"
+		app:layout_constraintStart_toStartOf="parent"
+		app:layout_constraintTop_toBottomOf="@+id/divider2"
+		style="@style/OptionItemStyle" />
+
+	<View
+		android:id="@+id/divider3"
+		android:layout_width="match_parent"
+		android:layout_height="@dimen/dimens_1dp"
+		android:layout_marginLeft="@dimen/dimens_10dp"
+		android:background="?android:attr/listDivider"
+		app:layout_constraintStart_toStartOf="parent"
+		app:layout_constraintTop_toBottomOf="@+id/access_graph_api" />
+
+	<Button
+		android:id="@+id/access_multiple_api"
+		android:layout_marginTop="@dimen/dimens_15dp"
+		android:layout_width="fill_parent"
+		android:layout_height="wrap_content"
+		android:text="Access Multiple APIs"
+		app:layout_constraintStart_toStartOf="parent"
+		app:layout_constraintTop_toBottomOf="@+id/divider3"
+		style="@style/OptionItemStyle" />
+
+	<View
+		android:id="@+id/divider4"
+		android:layout_width="match_parent"
+		android:layout_height="@dimen/dimens_1dp"
+		android:layout_marginLeft="@dimen/dimens_10dp"
+		android:background="?android:attr/listDivider"
+		app:layout_constraintStart_toStartOf="parent"
+		app:layout_constraintTop_toBottomOf="@+id/access_multiple_api" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <!-- Results -->
     <string name="result_account_text">"Account username: "</string>
     <string name="result_access_token_text">"Access token: "</string>
+    <string name="result_access_token_of_scopes_text">"Access Token of scopes "</string>
     <string name="result_id_token_text">"ID token: "</string>
     <string name="result_text">"Result: "</string>
     <string name="response_api">"API response is: "</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,7 +55,7 @@
     <!-- Results -->
     <string name="result_account_text">"Account username: "</string>
     <string name="result_access_token_text">"Access token: "</string>
-    <string name="result_access_token_of_scopes_text">"Access Token of scopes "</string>
+    <string name="result_access_token_of_scopes_text">"Access token of scopes:\n"</string>
     <string name="result_id_token_text">"ID token: "</string>
     <string name="result_text">"Result: "</string>
     <string name="response_api">"API response is: "</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="title_email_oob_sspr">"Password Reset"</string>
     <string name="title_more">"More"</string>
     <string name="title_web_fallback">"Web Fallback"</string>
-    <string name="title_access_web_api">"Access Web API"</string>
+    <string name="title_access_web_api">"Access Protected Web APIs"</string>
 
     <!-- General -->
     <string name="sign_in">"Sign In"</string>


### PR DESCRIPTION
Change Summary:
1. separate one button into two buttons after discussion with Marcos
2. signIn() instead of signIn(mergedScopes)
3. result Text 1&2 to single result text
4. update the title to give users a hint on the scopes
5. remove redundancy navigation item.
6. update the code comments
7. update the result string
8. at the onCreate we retrieve the cached account and show just the email
9. We retrieve the access token only when the user presses the button "getAPI1" or "getAPI2"
10. onResume we just don't do anything