### PR TITLE
Update the sample app due to attribute changes

### DIFF
--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -97,7 +97,7 @@ class EmailAttributeSignUpFragment : Fragment() {
             val country = binding.countryText.text.toString()
             val city = binding.cityText.text.toString()
 
-            val attributes = UserAttributes.Builder
+            val attributes = UserAttributes.Builder()
                 .country(country)
                 .city(city)
                 .build()


### PR DESCRIPTION
## Background
When using UserAttributes.Builder multiple times, e.g. when submitting attributes across multiple steps/screens, previously set data is persisted. This is due to the Builder (unintentionally) being a singleton. The impact of this is that unexpected/unintended user attributes are sent to the server, causing an incorrect user flow.

## Company PR
https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2145