### PR TITLE
Bush bash fixing

### DIFF
--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -107,7 +107,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                 password = password,
                 attributes = attributes
             )
-            binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
+            binding.passwordText.text?.clear()
             StringUtil.overwriteWithNull(password)
 
             when (actionResult) {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
@@ -115,6 +115,10 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                 is SignInResult.CodeRequired -> {
                     displayDialog(message = getString(R.string.sign_in_switch_to_otp_message))
                 }
+                is SignInResult.MFARequired -> {
+                    // Please refer to the MFA Fragment for handling MFA branches if conditional access - MFA is enabled.
+                    displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
+                }
                 is SignInError -> {
                     handleSignInError(actionResult)
                 }
@@ -132,7 +136,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
                 username = email,
                 password = password
             )
-            binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
+            binding.passwordText.text?.clear()
             StringUtil.overwriteWithNull(password)
 
             when (actionResult) {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailSignInSignUpFragment.kt
@@ -105,6 +105,10 @@ class EmailSignInSignUpFragment : Fragment() {
                 is SignInResult.PasswordRequired -> {
                     displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
                 }
+                is SignInResult.MFARequired -> {
+                    // Please refer to the MFA Fragment for handling MFA branches if conditional access - MFA is enabled.
+                    displayDialog(getString(R.string.unexpected_sdk_result_title), actionResult.toString())
+                }
                 is SignInError -> {
                     handleSignInError(actionResult)
                 }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
@@ -59,7 +59,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
             binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
 
             val actionResult: ResetPasswordSubmitPasswordResult = currentState.submitPassword(password)
-            binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
+            binding.passwordText.text?.clear()
             StringUtil.overwriteWithNull(password)
 
             when (actionResult) {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
@@ -94,11 +94,7 @@ class WebFallbackFragment : Fragment() {
                 username = email,
                 password = password
             )
-            binding.passwordText.text?.set(
-                0,
-                binding.passwordText.text?.length?.minus(1) ?: 0,
-                0
-            )
+            binding.passwordText.text?.clear()
             StringUtil.overwriteWithNull(password)
 
             if (actionResult is SignInError && actionResult.isBrowserRequired()) {


### PR DESCRIPTION
### Bug 1: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3069634
- Reason: There is no `MFARequired` or `else` branch in the original UI screens except from the additional MFAFragment.
- Solution: 
1. Add `MFARequired` branch in the `EmailPasswordSignInSignUpFragment.kt` and `EmailSignInSignUpFragment.kt`
2. Add comments for those `unexpected` result for guiding the developer to do the next step.
- Create a related future work PBI: https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/2655883/?workitem=3070455

### Bug 2: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3069611
- Reason: When the password is null, The behavior of `set(0, -1, 0)` of  `binding.passwordText.text?.length?.minus(1) ?: 0, 0` cause `IndexOutOfBoundsException` which crash the sample app. 
- Solution: Remove all legacy code and use `binding.passwordText.text?.clear()` instead