### PR TITLE
binding.passwordText.text?.clear()

### DIFF
--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -107,7 +107,7 @@ class EmailAttributeSignUpFragment : Fragment() {
                 password = password,
                 attributes = attributes
             )
-            binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
+            binding.passwordText.text?.clear()
             StringUtil.overwriteWithNull(password)
 
             when (actionResult) {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
@@ -59,7 +59,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
             binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
 
             val actionResult: ResetPasswordSubmitPasswordResult = currentState.submitPassword(password)
-            binding.passwordText.text?.set(0, binding.passwordText.text?.length?.minus(1) ?: 0, 0)
+            binding.passwordText.text?.clear()
             StringUtil.overwriteWithNull(password)
 
             when (actionResult) {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
@@ -94,11 +94,7 @@ class WebFallbackFragment : Fragment() {
                 username = email,
                 password = password
             )
-            binding.passwordText.text?.set(
-                0,
-                binding.passwordText.text?.length?.minus(1) ?: 0,
-                0
-            )
+            binding.passwordText.text?.clear()
             StringUtil.overwriteWithNull(password)
 
             if (actionResult is SignInError && actionResult.isBrowserRequired()) {


### PR DESCRIPTION
### Bug 2: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3069611
- Reason: When the password is null, The behavior of `set(0, -1, 0)` of  `binding.passwordText.text?.length?.minus(1) ?: 0, 0` cause `IndexOutOfBoundsException` which crash the sample app. 
- Solution: Remove all legacy code and use `binding.passwordText.text?.clear()` instead