### PR TITLE
Using fragment name for the pop up stack reference

### DIFF
--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MFAVerificationFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MFAVerificationFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentMfaChallengeBinding
 import com.microsoft.identity.nativeauth.statemachine.errors.MFARequestChallengeError
 import com.microsoft.identity.nativeauth.statemachine.errors.MFASubmitChallengeError
@@ -143,6 +144,9 @@ class MFAVerificationFragment : Fragment() {
     }
 
     private fun finish() {
-        requireActivity().supportFragmentManager.popBackStackImmediate()
+        // Pop back to PasswordResetFragment fragment
+        val fragmentManager = requireActivity().supportFragmentManager
+        val name: String = MFAFragment::class.java.name
+        fragmentManager.popBackStack(name, 0)
     }
 }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MainActivity.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.azuresamples.msalnativeauthandroidkotlinsampleapp
 
 import android.os.Bundle
+import android.text.TextUtils.replace
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.ActivityMainBinding
@@ -41,9 +42,9 @@ class MainActivity : AppCompatActivity() {
 
     private fun setCurrentFragment(fragment: Fragment, title: Int) {
         supportActionBar?.title = getString(title)
-        supportFragmentManager.beginTransaction().apply {
-            replace(R.id.scenario_fragment, fragment)
-            commit()
-        }
+        supportFragmentManager.beginTransaction()
+            .addToBackStack(fragment::class.java.name)
+            .replace(R.id.scenario_fragment, fragment)
+            .commit()
     }
 }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
@@ -119,8 +119,9 @@ class PasswordResetNewPasswordFragment : Fragment() {
     }
 
     private fun finish() {
+        // Pop back to PasswordResetFragment fragment
         val fragmentManager = requireActivity().supportFragmentManager
-        val name: String? = fragmentManager.getBackStackEntryAt(0).name
-        fragmentManager.popBackStack(name, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        val name: String = PasswordResetFragment::class.java.name
+        fragmentManager.popBackStack(name, 0)
     }
 }


### PR DESCRIPTION
## Purpose
Fix the bug https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/3145322

Debug summary: 
There is a more fragment in the stack which will not be popped up
More Fragment -> MFAFragment -> MFAVerificationFragment -> MFAFragment -> PasswordResetFragment -> PasswordResetCodeFragment -> PasswordResetNewPasswordFragment

Solution:
Use the Fragment name to direct to the specific fragment.