### PR TITLE
Update NativeAuth imports and added UI Automation intent based initialisation

### DIFF
--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AccessApiFragment.kt
@@ -9,7 +9,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentAccessApiBinding
-import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.parameters.NativeAuthGetAccessTokenParameters
 import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInParameters
@@ -110,7 +109,7 @@ class AccessApiFragment : Fragment() {
             val actionResult: SignInResult = authClient.signIn(signInParameters)
 
             binding.passwordText.text?.clear()
-            StringUtil.overwriteWithNull(password)
+            password.fill('\u0000')
 
             when (actionResult) {
                 is SignInResult.Complete -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AuthClient.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/AuthClient.kt
@@ -6,17 +6,22 @@ import android.util.Log
 import com.microsoft.identity.client.Logger
 import com.microsoft.identity.client.PublicClientApplication
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
+import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationParameters
 
 object AuthClient : Application() {
     private lateinit var authClient: INativeAuthPublicClientApplication
+
+    const val EXTRA_CLIENT_ID = "native_auth_client_id"
+    const val EXTRA_AUTHORITY_URL = "native_auth_authority_url"
 
     @JvmStatic
     fun getAuthClient(): INativeAuthPublicClientApplication {
         return authClient
     }
 
+    // Initialize the auth client with the provided clientId and authorityUrl, or with the default config file if they are not provided.
     @JvmStatic
-    fun initialize(context: Context) {
+    fun initialize(context: Context, clientId: String? = null, authorityUrl: String? = null) {
         Logger.getInstance().setExternalLogger { tag, logLevel, message, containsPII ->
             Log.e(
                 "MSAL",
@@ -24,9 +29,24 @@ object AuthClient : Application() {
             )
         }
 
-        authClient = PublicClientApplication.createNativeAuthPublicClientApplication(
-            context,
-            R.raw.auth_config_native_auth
-        )
+        // If clientId and authorityUrl are provided, create the auth client with the provided values. Otherwise, create the auth client with the default config file.
+        if (clientId != null && authorityUrl != null) {
+            val parameters = NativeAuthPublicClientApplicationParameters(
+                clientId = clientId,
+                authorityUrl = authorityUrl,
+                challengeTypes = listOf("oob", "password")
+            )
+            parameters.capabilities = listOf("mfa_required", "registration_required")
+
+            authClient = PublicClientApplication.createNativeAuthPublicClientApplication(
+                context,
+                parameters
+            )
+        } else {
+            authClient = PublicClientApplication.createNativeAuthPublicClientApplication(
+                context,
+                R.raw.auth_config_native_auth
+            )
+        }
     }
 }

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailAttributeSignUpFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailAttributeBinding
-import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.UserAttributes
 import com.microsoft.identity.nativeauth.parameters.NativeAuthGetAccessTokenParameters
@@ -111,7 +110,7 @@ class EmailAttributeSignUpFragment : Fragment() {
             val actionResult: SignUpResult = authClient.signUp(parameters)
 
             binding.passwordText.text?.clear()
-            StringUtil.overwriteWithNull(password)
+            password.fill('\u0000')
 
             when (actionResult) {
                 is SignUpResult.CodeRequired -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
@@ -9,8 +9,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailPasswordBinding
 import com.microsoft.identity.client.PublicClientApplication
-import com.microsoft.identity.nativeauth.NativeAuthRequestInterceptor;
-import com.microsoft.identity.common.java.util.StringUtil
+import com.microsoft.identity.nativeauth.NativeAuthRequestInterceptor
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
 import com.microsoft.identity.nativeauth.parameters.NativeAuthGetAccessTokenParameters
@@ -120,7 +119,7 @@ class EmailPasswordSignInSignUpFragment : Fragment(), NativeAuthRequestIntercept
             val actionResult: SignInResult = authClient.signIn(parameters)
 
             binding.passwordText.text?.clear()
-            StringUtil.overwriteWithNull(password)
+            password.fill('\u0000')
 
             when (actionResult) {
                 is SignInResult.Complete -> {
@@ -160,7 +159,7 @@ class EmailPasswordSignInSignUpFragment : Fragment(), NativeAuthRequestIntercept
             val actionResult: SignUpResult = authClient.signUp(parameters)
 
             binding.passwordText.text?.clear()
-            StringUtil.overwriteWithNull(password)
+            password.fill('\u0000')
 
             when (actionResult) {
                 is SignUpResult.CodeRequired -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/EmailPasswordSignInSignUpFragment.kt
@@ -9,7 +9,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailPasswordBinding
 import com.microsoft.identity.client.PublicClientApplication
-import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthRequestInterceptor
+import com.microsoft.identity.nativeauth.NativeAuthRequestInterceptor;
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MFAFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MFAFragment.kt
@@ -10,7 +10,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentEmailPasswordBinding
 import com.microsoft.identity.client.claims.ClaimsRequest
-import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.AuthMethod
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.parameters.NativeAuthGetAccessTokenParameters
@@ -102,7 +101,7 @@ class MFAFragment : Fragment() {
             parameters.password = password
             val actionResult: SignInResult = authClient.signIn(parameters)
             binding.passwordText.text?.clear()
-            StringUtil.overwriteWithNull(password)
+            password.fill('\u0000')
 
             when (actionResult) {
                 is SignInResult.Complete -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MainActivity.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/MainActivity.kt
@@ -18,7 +18,9 @@ class MainActivity : AppCompatActivity() {
         val binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        AuthClient.initialize(this@MainActivity)
+        val clientId = intent.getStringExtra(AuthClient.EXTRA_CLIENT_ID)
+        val authorityUrl = intent.getStringExtra(AuthClient.EXTRA_AUTHORITY_URL)
+        AuthClient.initialize(this@MainActivity, clientId, authorityUrl)
 
         val emailSignInSignUpFragment = EmailSignInSignUpFragment()
         val emailPasswordSignInSignUpFragment = EmailPasswordSignInSignUpFragment()

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/PasswordResetNewPasswordFragment.kt
@@ -9,7 +9,6 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.azuresamples.msalnativeauthandroidkotlinsampleapp.databinding.FragmentPasswordBinding
-import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInContinuationParameters
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordSubmitPasswordError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
@@ -60,7 +59,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
 
             val actionResult: ResetPasswordSubmitPasswordResult = currentState.submitPassword(password)
             binding.passwordText.text?.clear()
-            StringUtil.overwriteWithNull(password)
+            password.fill('\u0000')
 
             when (actionResult) {
                 is ResetPasswordResult.Complete -> {

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpAttributesFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpAttributesFragment.kt
@@ -56,10 +56,8 @@ class SignUpAttributesFragment : Fragment() {
 
     private fun submitAttributes() {
         CoroutineScope(Dispatchers.Main).launch {
-            val username = binding.usernameText.text.toString()
 
             val attributes = UserAttributes.Builder()
-                .flatUsername(username)
                 .build()
 
             val actionResult = currentState.submitAttributes(attributes)

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/SignUpCodeFragment.kt
@@ -72,7 +72,7 @@ class SignUpCodeFragment : Fragment() {
                 is SignUpResult.AttributesRequired -> {
                     // Custom implementation for Flat Username / Alias
                     if (actionResult.requiredAttributes.size == 1 &&
-                        actionResult.requiredAttributes.any { it.name == "flatusername" }
+                        actionResult.requiredAttributes.any { it.attributeName == "flatusername" }
                     ) {
                         navigateToAttributes(
                             nextState = actionResult.nextState

--- a/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
+++ b/app/src/main/java/com/azuresamples/msalnativeauthandroidkotlinsampleapp/WebFallbackFragment.kt
@@ -15,7 +15,6 @@ import com.microsoft.identity.client.AuthenticationCallback
 import com.microsoft.identity.client.IAccount
 import com.microsoft.identity.client.IAuthenticationResult
 import com.microsoft.identity.client.exception.MsalException
-import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInParameters
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccountError
@@ -96,7 +95,7 @@ class WebFallbackFragment : Fragment() {
             val actionResult: SignInResult = authClient.signIn(parameters)
 
             binding.passwordText.text?.clear()
-            StringUtil.overwriteWithNull(password)
+            password.fill('\u0000')
 
             if (actionResult is SignInError && actionResult.isBrowserRequired()) {
                 Toast.makeText(requireContext(), actionResult.errorMessage, Toast.LENGTH_SHORT)


### PR DESCRIPTION
## Changes

- **Updated import** for `NativeAuthRequestInterceptor` to use the new package location `com.microsoft.identity.nativeauth.NativeAuthRequestInterceptor`
- **Added intent-based initialization** — `AuthClient` and `MainActivity` now accept `clientId` and `authorityUrl` via intent extras, enabling UI automation tests to inject test tenant configuration at runtime without modifying bundled config files
- **Removed `StringUtil` dependency** — replaced `StringUtil.overwriteWithNull(password)` with Kotlin's built-in `password.fill('\u0000')` to avoid pulling in the common library dependency
- Reverted changes to flatUsername to prevent building error as PR for alias is not yet merged - https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2513

## Context

These changes support the new NativeAuth UI automation tests in `android-complete` ([PR #437](https://github.com/AzureAD/android-complete/pull/437)). The test launches NativeAuthSampleApp via `adb` with intent extras containing the CIAM tenant config, allowing end-to-end sign-in validation in the 1ES weekly pipeline via Firebase Test Lab.